### PR TITLE
Prioritize `display: none` in `.relaxngui_hidden`

### DIFF
--- a/relaxngui.css
+++ b/relaxngui.css
@@ -21,7 +21,7 @@
 }
 
 .relaxngui_table { }
-.relaxngui_hidden { display: none; }
+.relaxngui_hidden { display: none !important; }
 .relaxngui_table .relaxngui_table { }
 
 .relaxngui_table.closed > .relaxngui_table,


### PR DESCRIPTION
`display: hidden` set by `.relaxngui_hidden` is currently overwritten by `.relaxngui_row`.